### PR TITLE
OSOE-1129: Update to patched version of Slick and remove workaround

### DIFF
--- a/Lombiq.UIKit/package.json
+++ b/Lombiq.UIKit/package.json
@@ -6,6 +6,6 @@
     "watch": "npm explore nodejs-extensions -- pnpm watch"
   },
   "dependencies": {
-    "slick-carousel": "^1.8.1"
+    "slick-carousel": "github:kenwheeler/slick#0bce01e901628d038b3a5f6d0947e14fb0ae6016"
   }
 }

--- a/Lombiq.UIKit/pnpm-lock.yaml
+++ b/Lombiq.UIKit/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   slick-carousel:
-    specifier: ^1.8.1
-    version: 1.8.1(jquery@3.7.1)
+    specifier: github:kenwheeler/slick#0bce01e901628d038b3a5f6d0947e14fb0ae6016
+    version: github.com/kenwheeler/slick/0bce01e901628d038b3a5f6d0947e14fb0ae6016(jquery@3.7.1)
 
 packages:
 
@@ -15,8 +15,11 @@ packages:
     resolution: {integrity: sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==}
     dev: false
 
-  /slick-carousel@1.8.1(jquery@3.7.1):
-    resolution: {integrity: sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==}
+  github.com/kenwheeler/slick/0bce01e901628d038b3a5f6d0947e14fb0ae6016(jquery@3.7.1):
+    resolution: {tarball: https://codeload.github.com/kenwheeler/slick/tar.gz/0bce01e901628d038b3a5f6d0947e14fb0ae6016}
+    id: github.com/kenwheeler/slick/0bce01e901628d038b3a5f6d0947e14fb0ae6016
+    name: slick-carousel
+    version: 1.8.1
     peerDependencies:
       jquery: '>=1.8.0'
     dependencies:

--- a/Lombiq.UIKit/wwwroot/js/slick-carousel.js
+++ b/Lombiq.UIKit/wwwroot/js/slick-carousel.js
@@ -30,12 +30,6 @@ jQuery(($) => {
             carouselSettings.slide = '';
         }
 
-        $(carousel)
-            .on('init', () => {
-                // Carousel initializes elements with empty id attributes, which triggers HTML validation errors.
-                // See: https://github.com/kenwheeler/slick/issues/4296
-                carousel.querySelectorAll('[id=""]').forEach((element) => element.removeAttribute('id'));
-            })
-            .slick(carouselSettings);
+        $(carousel).slick(carouselSettings);
     });
 });


### PR DESCRIPTION
[OSOE-1129](https://lombiq.atlassian.net/browse/OSOE-1129)
This is related to https://github.com/kenwheeler/slick/pull/4331.

[OSOE-1129]: https://lombiq.atlassian.net/browse/OSOE-1129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ