### PR TITLE
OSOE-1210: Deactivating LibMan in CI due to Slick's restore being flaky

### DIFF
--- a/Lombiq.UIKit/Lombiq.UIKit.csproj
+++ b/Lombiq.UIKit/Lombiq.UIKit.csproj
@@ -35,10 +35,10 @@
     <PackageReference Include="OrchardCore.Contents" Version="2.1.0" />
     <PackageReference Include="OrchardCore.DisplayManagement" Version="2.1.0" />
     <PackageReference Include="OrchardCore.ResourceManagement" Version="2.1.0" />
-    <!-- This is deactivated in CI because restoring Slick via LibMan is flaky, see
-    https://github.com/Lombiq/GitHub-Actions/issues/549. So, we keep the library in the repository but LibMan can be
-    used to update the Slick snapshot. -->
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" Condition="'$(GITHUB_ENV)' == ''" />
+    <!-- This is commented out, because restoring Slick via LibMan is flaky, see
+    https://github.com/Lombiq/GitHub-Actions/issues/549. So, we keep the library in the repository. This should only be
+    temporarily uncommented while updating the Slick snapshot. -->
+    <!--<PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />-->
   </ItemGroup>
 
   <ItemGroup Condition="'$(NuGetBuild)' != 'true'">

--- a/Lombiq.UIKit/Lombiq.UIKit.csproj
+++ b/Lombiq.UIKit/Lombiq.UIKit.csproj
@@ -38,7 +38,7 @@
     <!-- This is commented out, because restoring Slick via LibMan is flaky, see
     https://github.com/Lombiq/GitHub-Actions/issues/549. So, we keep the library in the repository. This should only be
     temporarily uncommented while updating the Slick snapshot. -->
-    <!--<PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />-->
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" Condition="'$(GITHUB_ENV)' == ''" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(NuGetBuild)' != 'true'">

--- a/Lombiq.UIKit/Lombiq.UIKit.csproj
+++ b/Lombiq.UIKit/Lombiq.UIKit.csproj
@@ -36,8 +36,10 @@
     <PackageReference Include="OrchardCore.DisplayManagement" Version="2.1.0" />
     <PackageReference Include="OrchardCore.ResourceManagement" Version="2.1.0" />
     <!-- This is commented out, because restoring Slick via LibMan is flaky, see
-    https://github.com/Lombiq/GitHub-Actions/issues/549. So, we keep the library in the repository. This should only be
-    temporarily uncommented while updating the Slick snapshot. -->
+    https://github.com/Lombiq/GitHub-Actions/issues/549. So, we keep the library in the repository. Uncomment this
+    temporarily while updating the Slick snapshot locally. It's not enabled locally either because we don't gain
+    anything by it except for the rare cases of updates, but since LibMan touches the files, they'll show up as changed
+    in Git (at least in Git Extensions), even though their contents didn't change. -->
     <!--<PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />-->
   </ItemGroup>
 

--- a/Lombiq.UIKit/Lombiq.UIKit.csproj
+++ b/Lombiq.UIKit/Lombiq.UIKit.csproj
@@ -35,9 +35,9 @@
     <PackageReference Include="OrchardCore.Contents" Version="2.1.0" />
     <PackageReference Include="OrchardCore.DisplayManagement" Version="2.1.0" />
     <PackageReference Include="OrchardCore.ResourceManagement" Version="2.1.0" />
-    <!-- This is commented out, because restoring Slick via LibMan is flaky, see
-    https://github.com/Lombiq/GitHub-Actions/issues/549. So, we keep the library in the repository. This should only be
-    temporarily uncommented while updating the Slick snapshot. -->
+    <!-- This is deactivated in CI because restoring Slick via LibMan is flaky, see
+    https://github.com/Lombiq/GitHub-Actions/issues/549. So, we keep the library in the repository but LibMan can be
+    used to update the Slick snapshot. -->
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" Condition="'$(GITHUB_ENV)' == ''" />
   </ItemGroup>
 

--- a/Lombiq.UIKit/Lombiq.UIKit.csproj
+++ b/Lombiq.UIKit/Lombiq.UIKit.csproj
@@ -35,7 +35,10 @@
     <PackageReference Include="OrchardCore.Contents" Version="2.1.0" />
     <PackageReference Include="OrchardCore.DisplayManagement" Version="2.1.0" />
     <PackageReference Include="OrchardCore.ResourceManagement" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />
+    <!-- This is commented out, because restoring Slick via LibMan is flaky, see
+    https://github.com/Lombiq/GitHub-Actions/issues/549. So, we keep the library in the repository. This should only be
+    temporarily uncommented while updating the Slick snapshot. -->
+    <!--<PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />-->
   </ItemGroup>
 
   <ItemGroup Condition="'$(NuGetBuild)' != 'true'">

--- a/Lombiq.UIKit/libman.json
+++ b/Lombiq.UIKit/libman.json
@@ -4,7 +4,7 @@
   "libraries": [
     {
       "note": "This entry refers to a specific GitHub commit mirrored by jsDelivr. Its API requires the commit hash to be in the short form. If Renovate automatically updates the value after the at sign below, it has to be manually shortened or the build will fail.",
-      "note2": "WARNING: When updating the reference, shorten the digest and update the library's snapshot in the repo via building it locally.",
+      "note2": "WARNING: When updating the reference, enable Microsoft.Web.LibraryManager.Build in the csproj and follow the comment there.",
       "library": "kenwheeler/slick@ecb6ea2",
       "destination": "wwwroot/vendors",
       "files": [ "slick/**/*" ]

--- a/Lombiq.UIKit/libman.json
+++ b/Lombiq.UIKit/libman.json
@@ -4,7 +4,7 @@
   "libraries": [
     {
       "note": "This entry refers to a specific GitHub commit mirrored by jsDelivr. Its API requires the commit hash to be in the short form. If Renovate automatically updates the value after the at sign below, it has to be manually shortened or the build will fail.",
-      "note2": "WARNING: When updating the reference, enable Microsoft.Web.LibraryManager.Build in the csproj and follow the comment there.",
+      "note2": "WARNING: When updating the reference, shorten the digest and update the library's snapshot in the repo via building it locally.",
       "library": "kenwheeler/slick@ecb6ea2",
       "destination": "wwwroot/vendors",
       "files": [ "slick/**/*" ]

--- a/Lombiq.UIKit/libman.json
+++ b/Lombiq.UIKit/libman.json
@@ -4,6 +4,7 @@
   "libraries": [
     {
       "note": "This entry refers to a specific GitHub commit mirrored by jsDelivr. Its API requires the commit hash to be in the short form. If Renovate automatically updates the value after the at sign below, it has to be manually shortened or the build will fail.",
+      "note2": "WARNING: When updating the reference, enable Microsoft.Web.LibraryManager.Build in the csproj and follow the comment there.",
       "library": "kenwheeler/slick@ecb6ea2",
       "destination": "wwwroot/vendors",
       "files": [ "slick/**/*" ]


### PR DESCRIPTION
[OSOE-1210](https://lombiq.atlassian.net/browse/OSOE-1210)
This is an ugly hack, but keeping the Slick digest up-to-date is already a manual process, and I see no point in implementing some sophosticated workaround for the flaky restores just for this one library.

[OSOE-1210]: https://lombiq.atlassian.net/browse/OSOE-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ